### PR TITLE
GATT Bearer 'MTU' negotiation updates

### DIFF
--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/ble/BleMeshManager.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/ble/BleMeshManager.java
@@ -95,7 +95,6 @@ public class BleMeshManager extends BleManager<BleMeshManagerCallbacks> {
         protected Deque<Request> initGatt(final BluetoothGatt gatt) {
             mBluetoothGatt = gatt;
             final LinkedList<Request> requests = new LinkedList<>();
-            requests.push(Request.newMtuRequest(MTU_SIZE_MAX));
             if (isProvisioningComplete) {
                 requests.push(Request.newReadRequest(mMeshProxyDataInCharacteristic));
                 requests.push(Request.newReadRequest(mMeshProxyDataOutCharacteristic));
@@ -105,6 +104,7 @@ public class BleMeshManager extends BleManager<BleMeshManagerCallbacks> {
                 requests.push(Request.newReadRequest(mMeshProvisioningDataOutCharacteristic));
                 requests.push(Request.newEnableNotificationsRequest(mMeshProvisioningDataOutCharacteristic));
             }
+            requests.push(Request.newMtuRequest(MTU_SIZE_MAX));
             return requests;
         }
 


### PR DESCRIPTION
Also, the "ATT Exchange MTU" operation happens after the "Data Out CCCD" is being configured. This could lead to a situation where the Server sends some valid segmented data prior to the Exchange MTU procedure is initiated. Typically, most of the available mesh solutions/apps establish the MTU negotiations before the "Data out CCCD" is configured. Either one could "Push" the Exchange MTU request to the "Dequeue" after the enable CCCD command or one could "add" all the commands to "Dequeue" instead of "push" with the original code sequence for the commands not modified.